### PR TITLE
Replace broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MineTek Reborn Fork
 ===================
 
-This is fork of MineTek (https://github.com/ScarecrowKrone/MineTek) modpack from version 2.8.7.
+This is fork of MineTek (http://www.technicpack.net/modpack/minetek.52352) modpack from version 2.8.7.
 
 Changelog
 =========


### PR DESCRIPTION
The old repo has been deleted, so you should probably link to the platform page instead.
